### PR TITLE
Replacing GitHub Jobs with DevITjobs.us

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,7 @@
     + [Masonry](http://masonry.desandro.com/)  JavaScript Cascading grid layout library
     + [MixItUp](https://mixitup.kunkalabs.com/) jQuery plugin providing animated filtering and sorting.
 + Jobs & Hiring
-    + [GitHub Jobs](https://jobs.github.com/)
+    + [DevITjobs](https://devitjobs.us)
     + [Authentic Jobs](http://www.authenticjobs.com/)
     + [37signals Job Board](http://jobs.37signals.com/)
     + [Smashing Jobs](http://jobs.smashingmagazine.com/)


### PR DESCRIPTION
GitHub jobs does not exist anymore: https://github.blog/changelog/2021-04-19-deprecation-notice-github-jobs-site

